### PR TITLE
fix linux header dependencies to install on debian jessie

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Description: Debug symbols for the userhdhomerun application.
 
 Package: dvbhdhomerun-source
 Architecture: all
-Depends: module-assistant, build-essential, debhelper (>= 7), make, bzip2, linux-headers-generic | linux-headers
+Depends: module-assistant, build-essential, debhelper (>= 7), make, bzip2, linux-headers-686-pae | linux-headers-amd64 | linux-headers-generic | linux-headers
 Description: Source for the dvbhdhomerun kernel driver.
  This package provides the source code for the dvbhdhomerun kernel modules, to
  be build with module-assistant. The dvbhdhomerun-utils package is required in
@@ -30,7 +30,7 @@ Description: Source for the dvbhdhomerun kernel driver.
 
 Package: dvbhdhomerun-dkms
 Architecture: all
-Depends: dkms (>= 1.95), build-essential, debhelper (>= 7), make, curl, bzip2, linux-headers-generic | linux-headers
+Depends: dkms (>= 1.95), build-essential, debhelper (>= 7), make, curl, bzip2, linux-headers-686-pae | linux-headers-amd64 | linux-headers-generic | linux-headers
 Description: Source for the dvbhdhomerun kernel driver.
  This package provides the source code for the dvbhdhomerun kernel modules, to
  be build with dkms. The dvbhdhomerun-utils package is required in order to make


### PR DESCRIPTION
For some reason debian jessie does not currently have the meta packages linux-header or linux-header-generic. I looked at the dkms package to see what it was using for depends/recommends.
