### PR TITLE
Make debian/control Build-depends include dh-systemd, bracket dh_inst…

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: dvbhdhomerun
 Section: video
 Priority: extra
 Maintainer: Jeffrey Clark <dude@zaplabs.com>
-Build-Depends: debhelper (>= 7), cmake, libhdhomerun-dev, dkms
+Build-Depends: debhelper (>= 7), cmake, libhdhomerun-dev, dkms, dh-systemd
 Standards-Version: 3.9.4
 Homepage: https://github.com/h0tw1r3/dvbhdhomerun
 

--- a/debian/rules
+++ b/debian/rules
@@ -62,7 +62,9 @@ install: build
 
 	ln -s ../packages/default.sh debian/dvbhdhomerun-utils/usr/share/modass/overrides/dvbhdhomerun-source
 
+	dh_systemd_enable
 	dh_install
+	dh_systemd_start
 
 # Build architecture-independent files here.
 binary-indep: build install

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -16,12 +16,12 @@ all: dlheaders dvb_hdhomerun
 
 dlheaders: dlmain
 	@echo Downloading kernel header dependencies...
-	@$(foreach var,$(shell grep -h ^\\\#include\ \" $(PWD)/headers/$(KVERMAJ).$(KVERMIN)/*.[ch] 2>/dev/null | sort -u | sed 's/\#include "\(.*\)"/\1/'),curl -# -L -o $(PWD)/headers/$(KVERMAJ).$(KVERMIN)/$(var) https://github.com/torvalds/linux/raw/v$(KVERMAJ).$(KVERMIN)/drivers/media$(HEADERSUBFOLDER)/dvb-core/$(var);)
+	@$(foreach var,$(shell grep -h ^\\\#include\ \" $(PWD)/headers/$(KVERMAJ).$(KVERMIN)/*.[ch] 2>/dev/null | sort -u | sed 's/\#include "\(.*\)"/\1/'),curl -# -L -o $(PWD)/headers/$(KVERMAJ).$(KVERMIN)/$(var) https://raw.githubusercontent.com/torvalds/linux/master/drivers/media/dvb-core/$(var);)
 
 dlmain:
 	@echo Downloading kernel headers...
 	@mkdir -p $(PWD)/headers/$(KVERMAJ).$(KVERMIN)
-	@$(foreach var,$(shell grep -h ^\\\#include\ \" *.[ch] 2>/dev/null | grep -v hdhomerun | sort -u | sed 's/\#include "\(.*\)"/\1/'),curl -# -L -o $(PWD)/headers/$(KVERMAJ).$(KVERMIN)/$(var) https://github.com/torvalds/linux/raw/v$(KVERMAJ).$(KVERMIN)/drivers/media$(HEADERSUBFOLDER)/dvb-core/$(var);)
+	@$(foreach var,$(shell grep -h ^\\\#include\ \" *.[ch] 2>/dev/null | grep -v hdhomerun | sort -u | sed 's/\#include "\(.*\)"/\1/'),curl -# -L -o $(PWD)/headers/$(KVERMAJ).$(KVERMIN)/$(var) https://raw.githubusercontent.com/torvalds/linux/master/drivers/media/dvb-core/$(var);)
 
 dvb_hdhomerun:
 	$(MAKE) -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) modules

--- a/kernel/dvb_hdhomerun_control_messages.h
+++ b/kernel/dvb_hdhomerun_control_messages.h
@@ -60,7 +60,7 @@ struct dvbhdhomerun_control_mesg {
 	unsigned int type;
 	union {
 		unsigned int frequency;
-		fe_status_t fe_status;
+		enum fe_status frontend_status;
 		int16_t signal_strength;
 		struct dmx_pes_filter_params dmx_pes_filter;
 		struct hdhomerun_dvb_demux_feed demux_feed;

--- a/kernel/dvb_hdhomerun_fe.c
+++ b/kernel/dvb_hdhomerun_fe.c
@@ -49,7 +49,7 @@ struct dvb_hdhomerun_fe_state {
 
 extern int hdhomerun_debug_mask;
 
-static int dvb_hdhomerun_fe_read_status(struct dvb_frontend* fe, fe_status_t* status)
+static int dvb_hdhomerun_fe_read_status(struct dvb_frontend* fe, enum fe_status* status)
 {
 	struct dvbhdhomerun_control_mesg mesg;
 	struct dvb_hdhomerun_fe_state* state = fe->demodulator_priv;
@@ -60,7 +60,7 @@ static int dvb_hdhomerun_fe_read_status(struct dvb_frontend* fe, fe_status_t* st
 	mesg.id = state->id;
 	hdhomerun_control_post_and_wait(&mesg);
 
-	*status = mesg.u.fe_status;
+	*status = mesg.u.frontend_status;
 
 	return 0;
 }
@@ -203,7 +203,7 @@ static int dvb_hdhomerun_fe_tune(struct dvb_frontend *fe, bool re_tune,
 #else
 static int dvb_hdhomerun_fe_tune(struct dvb_frontend *fe, struct dvb_frontend_parameters *params,
 #endif
-					unsigned int mode_flags, unsigned int *delay, fe_status_t *status)
+					unsigned int mode_flags, unsigned int *delay, enum fe_status *status)
 {
    int ret;
 	DEBUG_FUNC(1);

--- a/userhdhomerun/hdhomerun_control.cpp
+++ b/userhdhomerun/hdhomerun_control.cpp
@@ -219,9 +219,9 @@ void Control::FE_READ_Status(struct dvbhdhomerun_control_mesg& _mesg)
 
   HdhomerunTuner* tuner = m_hdhomerun->GetTuner(_mesg.id);
   if(tuner) {
-     fe_status_t status = (fe_status_t)tuner->ReadStatus();
+     fe_status status = (fe_status)tuner->ReadStatus();
   
-     _mesg.u.fe_status = status;
+     _mesg.u.frontend_status = status;
   }
   else {
      ERR() << "Tuner id does not exist!" << _mesg.id << endl;


### PR DESCRIPTION
This appears to start the userland stuff successfully on (K)Ubuntu 15.04 with systemd.  Props to whoever wrote the systemd service file already!